### PR TITLE
Adding a pg addon on the scalingo.json

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -4,6 +4,11 @@
   "logo": "https://scalingo.com/logo.svg",
   "repository": "https://github.com/Scalingo/sample-python-django",
   "website": "https://scalingo.com",
+  "addons": [
+    {
+      "plan": "postgresql:postgresql-sandbox"
+    }
+  ],
   "formation": {
     "web": {
       "amount": 1,


### PR DESCRIPTION
Sample requires to have a default DB, otherwise deployment fails